### PR TITLE
Fix CA update in Docker environment

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,11 +1,10 @@
-FROM centurylink/ca-certs
+FROM alpine
+RUN apk update && apk upgrade && apk add --no-cache ca-certificates
+RUN update-ca-certificates
 
+FROM scratch
 COPY dist /
-
 VOLUME /data
-
 WORKDIR /
-
 EXPOSE 9000
-
 ENTRYPOINT ["/whale"]


### PR DESCRIPTION
Drop `centurylink/ca-certs` and use alpine to update CA certificates during build